### PR TITLE
Fix sign-up loading state variable name

### DIFF
--- a/src/Modules/Authentication/SignUp.js
+++ b/src/Modules/Authentication/SignUp.js
@@ -19,7 +19,7 @@ function SignUp() {
     const navigate = useNavigate();
     const { isError, message } = useSelector(selectUserReducer, shallowEqual);
     const user = useSelector(selectUser);
-    const singUpIsLoading = useSelector(selectUserIsLoading);
+    const signUpIsLoading = useSelector(selectUserIsLoading);
 
     useEffect(() => {
         if (isError) {
@@ -63,7 +63,7 @@ function SignUp() {
 
     return (
         <>
-            {singUpIsLoading ? (
+            {signUpIsLoading ? (
                 <FullLoader />
             ) : (
                 <div className="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">


### PR DESCRIPTION
## Summary
- fix typo in `signUpIsLoading` variable

## Testing
- `npm run test:coverage` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68619419e854832a81a087b60ac047ed