### PR TITLE
Fix dispatch for delete event

### DIFF
--- a/src/Modules/Shared/EventModal.js
+++ b/src/Modules/Shared/EventModal.js
@@ -155,7 +155,7 @@ const EventModal = ({ type, close, opened, eventData = {}, eventList }) => {
 
                     <Group justify="flex-end" mt="md">
                         <Button type="submit">Save</Button>
-                        {type === 'edit' && <Button onClick={() => deleteEvent({ id: _id })} type="button" color="red">Delete</Button>}
+                        {type === 'edit' && <Button onClick={() => dispatch(deleteEvent(_id))} type="button" color="red">Delete</Button>}
                     </Group>
                 </form>
             </Modal>


### PR DESCRIPTION
## Summary
- use dispatch when deleting event

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_686194b24330832abced81c702d4a271